### PR TITLE
Add alignas type specifier to r_buffer in whd_resources.c

### DIFF
--- a/WiFi_Host_Driver/resources/resource_imp/whd_resources.c
+++ b/WiFi_Host_Driver/resources/resource_imp/whd_resources.c
@@ -18,6 +18,7 @@
 /** @file
  * Defines WHD resource functions for BCM943340WCD1 platform
  */
+#include <stdalign.h>
 #include "resources.h"
 #if !defined(NO_CLM_BLOB_FILE)
 #include "clm_resources.h"
@@ -80,7 +81,7 @@ extern const resource_hnd_t wifi_firmware_image;
 extern const resource_hnd_t wifi_firmware_clm_blob;
 #endif /* WLAN_MFG_FIRMWARE */
 
-unsigned char r_buffer[BLOCK_BUFFER_SIZE];
+alignas(4) unsigned char r_buffer[BLOCK_BUFFER_SIZE];
 
 #if defined(WHD_DYNAMIC_NVRAM)
 uint32_t dynamic_nvram_size = sizeof(wifi_nvram_image);


### PR DESCRIPTION
1. This buffer is passed back by whd_get_resource_block.
2. In whd_bus_spi_protocol.c whd_bus_spi_download_resource, the buffer is cast to uint32_t* and then an uint32 is copied out. This may crash with unaligned read if the buffer was not allocated on 4 byte boundary.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
In whd_bus_spi_protocol.c whd_bus_spi_download_resource, the buffer is cast to uint32_t* and then an uint32 is copied out. This may crash with unaligned read if the buffer was not allocated on 4 byte boundary.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
Ran into this while trying to use this code in zephyr to talk to CYW43439 on raspberry pi pico board.